### PR TITLE
feat: implement gapless audio looping for ambient sounds with buffer

### DIFF
--- a/components/apps/ambient-sounds.tsx
+++ b/components/apps/ambient-sounds.tsx
@@ -683,6 +683,15 @@ export function AmbientSounds() {
                 audio.volume =
                   normalizeVolume(sound.volume) * normalizeVolume(masterVolume);
 
+                // Implement gapless loop by resetting audio position before it reaches the end
+                audio.addEventListener("timeupdate", () => {
+                  // Reset position 0.5 seconds before the end to create a seamless loop
+                  const buffer = 0.8;
+                  if (audio.currentTime > audio.duration - buffer) {
+                    audio.currentTime = 0;
+                  }
+                });
+
                 // Set up error handling
                 audio.onerror = () => {
                   console.error(`Error loading sound ${soundId}`);

--- a/components/apps/ambient-sounds.tsx
+++ b/components/apps/ambient-sounds.tsx
@@ -685,7 +685,7 @@ export function AmbientSounds() {
 
                 // Implement gapless loop by resetting audio position before it reaches the end
                 audio.addEventListener("timeupdate", () => {
-                  // Reset position 0.5 seconds before the end to create a seamless loop
+                  // Reset position 0.8 seconds before the end to create a seamless loop
                   const buffer = 0.8;
                   if (audio.currentTime > audio.duration - buffer) {
                     audio.currentTime = 0;


### PR DESCRIPTION
Implement Gapless Audio Loop for Ambient Sounds

Problem
The current implementation of ambient sounds has a noticeable gap when audio loops, particularly affecting continuous sounds like white noise, brown noise, and other ambient sounds that should play seamlessly. This interruption creates a jarring experience for users who are trying to focus or relax.

Solution
Implemented a more sophisticated audio looping mechanism that creates truly gapless playback by:
Resetting the audio position to the beginning before it reaches the end (0.8 seconds before completion)

(audio.loop is actually crap)

To test this you can compare the actual behavior on "noise" topic of sound mixer
![image](https://github.com/user-attachments/assets/f3d3048e-af39-4ce7-bb75-fe49ba1adfb2)
